### PR TITLE
Feat/37/product read all

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -1,3 +1,5 @@
 export * from './types/product';
 export * from './types/TCategory';
 export * from './types/TImage';
+export * from './types/TLocation';
+export * from './types/TUser';

--- a/common/types/TCategory.ts
+++ b/common/types/TCategory.ts
@@ -3,4 +3,4 @@ type TCategory = {
   name: string;
 };
 
-export { TCategory };
+export default TCategory;

--- a/common/types/TImage.ts
+++ b/common/types/TImage.ts
@@ -3,7 +3,7 @@ import { TProduct } from './product';
 type TImage = {
   id: number;
   url: string;
-  productId: Pick<TProduct, 'id'>;
+  productId: TProduct['id'];
 };
 
 export default TImage;

--- a/common/types/TImage.ts
+++ b/common/types/TImage.ts
@@ -1,6 +1,9 @@
+import { TProduct } from './product';
+
 type TImage = {
   id: number;
   url: string;
+  productId: Pick<TProduct, 'id'>;
 };
 
 export default TImage;

--- a/common/types/TLocation.ts
+++ b/common/types/TLocation.ts
@@ -1,0 +1,6 @@
+type TLocation = {
+  id: number;
+  region: string;
+};
+
+export default TLocation;

--- a/common/types/TUser.ts
+++ b/common/types/TUser.ts
@@ -3,8 +3,8 @@ import TLocation from './TLocation';
 type TUser = {
   id: number;
   name: string;
-  location1Id: Pick<TLocation, 'id'>;
-  location2Id?: Pick<TLocation, 'id'>;
+  location1Id: TLocation['id'];
+  location2Id?: TLocation['id'];
 };
 
 export default TUser;

--- a/common/types/TUser.ts
+++ b/common/types/TUser.ts
@@ -1,0 +1,10 @@
+import TLocation from './TLocation';
+
+type TUser = {
+  id: number;
+  name: string;
+  location1Id: Pick<TLocation, 'id'>;
+  location2Id?: Pick<TLocation, 'id'>;
+};
+
+export default TUser;

--- a/common/types/product/TProduct.ts
+++ b/common/types/product/TProduct.ts
@@ -1,20 +1,21 @@
-import TImage from '../TImage';
+import TCategory from 'types/TCategory';
+import TLocation from 'types/TLocation';
+import TUser from 'types/TUser';
+import { EProductStatus } from './EProductStatus';
 
 type TProduct = {
   id: number;
   title: string;
+  content: string;
   price: number;
-  titleImage?: TImage;
-  likes: number;
-  isLike: boolean;
-  chats: number;
+  hit: number;
+  status: EProductStatus;
+  userId: TUser['id'];
+  locationId: TLocation['id'];
+  categoryId: TCategory['id'];
   createdAt?: Date;
   updatedAt?: Date;
   deletedAt?: Date;
-  locationId: number;
-  locationName: string;
-  userId: number;
-  userName: string;
 };
 
 export default TProduct;

--- a/common/types/product/TProductAllQuery.ts
+++ b/common/types/product/TProductAllQuery.ts
@@ -1,0 +1,9 @@
+import TLocation from '../TLocation';
+import TCategory from '../TCategory';
+
+type TProductAllQuery = {
+  locationId: TLocation['id'];
+  categoryId?: TCategory['id'];
+};
+
+export default TProductAllQuery;

--- a/common/types/product/TProductCreate.ts
+++ b/common/types/product/TProductCreate.ts
@@ -1,11 +1,11 @@
 import TImage from '../TImage';
+import TProduct from './TProduct';
 
-type TProductCreate = {
-  title: string;
-  content?: string;
-  price: number;
+type TProductCreate = Pick<
+  TProduct,
+  'title' | 'content' | 'price' | 'categoryId'
+> & {
   images?: TImage[];
-  categoryId: number;
 };
 
 export default TProductCreate;

--- a/common/types/product/TProductDetail.ts
+++ b/common/types/product/TProductDetail.ts
@@ -1,14 +1,17 @@
 import TProduct from './TProduct';
-import { EProductStatus } from './EProductStatus';
 import TImage from '../TImage';
+import TLocation from 'types/TLocation';
+import TUser from 'types/TUser';
+import TCategory from 'types/TCategory';
 
 type TProductDetail = TProduct & {
-  content?: string;
-  categoryId: number;
-  categoryName: string;
-  status: EProductStatus;
-  hits: number;
-  images?: TImage[];
+  images: TImage[];
+  userName: TUser['name'];
+  locationName: TLocation['region'];
+  categoryName: TCategory['name'];
+  likes: number;
+  isLike: boolean;
+  chatCount: number;
 };
 
 export default TProductDetail;

--- a/common/types/product/TProductSummary.ts
+++ b/common/types/product/TProductSummary.ts
@@ -1,0 +1,16 @@
+import TProduct from './TProduct';
+import TImage from '../TImage';
+
+type TProductSummary = Omit<
+  TProduct,
+  'content' | 'hit' | 'status' | 'categoryId'
+> & {
+  titleImage?: TImage['url'];
+  likes: number;
+  isLike: boolean;
+  chats: number;
+  locationName: string;
+  userName: string;
+};
+
+export default TProductSummary;

--- a/common/types/product/TProductUpdate.ts
+++ b/common/types/product/TProductUpdate.ts
@@ -1,14 +1,5 @@
-import { EProductStatus } from './EProductStatus';
-import TImage from '../TImage';
+import TProductCreate from './TProductCreate';
 
-type TProductUpdate = {
-  title?: string;
-  content?: string;
-  price?: number;
-  images?: TImage[];
-  status?: EProductStatus;
-  categoryId?: number;
-  isLike?: boolean;
-};
+type TProductUpdate = Partial<TProductCreate>;
 
 export default TProductUpdate;

--- a/common/types/product/index.ts
+++ b/common/types/product/index.ts
@@ -1,4 +1,5 @@
 export { default as TProduct } from './TProduct';
+export { default as TProductAllQuery } from './TProductAllQuery';
 export { default as TProductCreate } from './TProductCreate';
 export { default as TProductDetail } from './TProductDetail';
 export { default as TProductSummary } from './TProductSummary';

--- a/common/types/product/index.ts
+++ b/common/types/product/index.ts
@@ -1,5 +1,6 @@
 export { default as TProduct } from './TProduct';
 export { default as TProductCreate } from './TProductCreate';
 export { default as TProductDetail } from './TProductDetail';
+export { default as TProductSummary } from './TProductSummary';
 export { default as TProductUpdate } from './TProductUpdate';
 export { ProductStatus, EProductStatus } from './EProductStatus';

--- a/server/src/domain/product/entities/product.entity.ts
+++ b/server/src/domain/product/entities/product.entity.ts
@@ -21,7 +21,7 @@ export class Product {
   @PrimaryGeneratedColumn({ type: 'int' })
   id: number;
 
-  @Column({ type: 'varchar', length: 10 })
+  @Column({ type: 'varchar', length: 50 })
   title: string;
 
   @Column({ type: 'text' })

--- a/server/src/domain/product/product.controller.ts
+++ b/server/src/domain/product/product.controller.ts
@@ -27,7 +27,7 @@ export class ProductController {
   async findAll(@Query() query: TProductAllQuery, @Res() res: Response) {
     // TODO : User 정보를 가져와서 id 넘겨주기
     const data = await this.productService.findAllByQuery(query, undefined);
-    return res.status(HttpStatus.OK).json(data);
+    return res.status(HttpStatus.OK).json({ products: data });
   }
 
   @Get(':id')

--- a/server/src/domain/product/product.controller.ts
+++ b/server/src/domain/product/product.controller.ts
@@ -25,7 +25,8 @@ export class ProductController {
 
   @Get()
   async findAll(@Query() query: TProductAllQuery, @Res() res: Response) {
-    const data = await this.productService.findAllByQuery(query);
+    // TODO : User 정보를 가져와서 id 넘겨주기
+    const data = await this.productService.findAllByQuery(query, undefined);
     return res.status(HttpStatus.OK).json(data);
   }
 

--- a/server/src/domain/product/product.controller.ts
+++ b/server/src/domain/product/product.controller.ts
@@ -9,7 +9,6 @@ import {
   Query,
   Res,
   HttpStatus,
-  HttpException,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { ProductService } from './product.service';
@@ -26,16 +25,6 @@ export class ProductController {
 
   @Get()
   async findAll(@Query() query: TProductAllQuery, @Res() res: Response) {
-    const { locationId } = query;
-    if (!locationId)
-      throw new HttpException(
-        {
-          status: HttpStatus.BAD_REQUEST,
-          message: '물품 요청 : 잘못된 위치 아이디입니다.',
-        },
-        HttpStatus.BAD_REQUEST,
-      );
-
     const data = await this.productService.findAllByQuery(query);
     return res.status(HttpStatus.OK).json(data);
   }

--- a/server/src/domain/product/product.controller.ts
+++ b/server/src/domain/product/product.controller.ts
@@ -6,8 +6,14 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
+  Res,
+  HttpStatus,
+  HttpException,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { ProductService } from './product.service';
+import type { TProductAllQuery } from '@fleamarket/common';
 
 @Controller('product')
 export class ProductController {
@@ -19,8 +25,19 @@ export class ProductController {
   }
 
   @Get()
-  findAll() {
-    return this.productService.findAll();
+  async findAll(@Query() query: TProductAllQuery, @Res() res: Response) {
+    const { locationId } = query;
+    if (!locationId)
+      throw new HttpException(
+        {
+          status: HttpStatus.BAD_REQUEST,
+          message: '물품 요청 : 잘못된 위치 아이디입니다.',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+
+    const data = await this.productService.findAllByQuery(query);
+    return res.status(HttpStatus.OK).json(data);
   }
 
   @Get(':id')

--- a/server/src/domain/product/product.service.ts
+++ b/server/src/domain/product/product.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DeleteResult, Repository } from 'typeorm';
 import { Product } from './entities/product.entity';
+import type { TProductAllQuery } from '@fleamarket/common';
 
 @Injectable()
 export class ProductService {
@@ -18,8 +19,11 @@ export class ProductService {
     return product;
   }
 
-  findAll() {
-    return this.productRepository.find();
+  findAllByQuery(query: TProductAllQuery) {
+    const { locationId, categoryId } = query;
+    if (!categoryId) query = { locationId };
+
+    return this.productRepository.find({ where: query });
   }
 
   async findOne(id: number) {

--- a/server/src/domain/product/product.service.ts
+++ b/server/src/domain/product/product.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DeleteResult, Repository } from 'typeorm';
 import { Product } from './entities/product.entity';
@@ -19,11 +19,31 @@ export class ProductService {
     return product;
   }
 
-  findAllByQuery(query: TProductAllQuery) {
+  async findAllByQuery(query: TProductAllQuery) {
     const { locationId, categoryId } = query;
+    if (!locationId) {
+      throw new HttpException(
+        {
+          status: HttpStatus.BAD_REQUEST,
+          message: '물품 요청 : 잘못된 위치 아이디입니다.',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
     if (!categoryId) query = { locationId };
 
-    return this.productRepository.find({ where: query });
+    try {
+      const data = await this.productRepository.find({ where: query });
+      return data;
+    } catch (e) {
+      throw new HttpException(
+        {
+          status: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: '물품 요청 : 물품을 찾는데 문제가 있습니다.',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
   }
 
   async findOne(id: number) {

--- a/server/src/domain/product/product.service.ts
+++ b/server/src/domain/product/product.service.ts
@@ -70,7 +70,7 @@ export class ProductService {
         .groupBy('p.id, image.id')
         .execute();
 
-      return data as any;
+      return data as TProductSummary[];
     } catch (e) {
       console.log(e);
       throw new HttpException(

--- a/server/src/domain/product/product.service.ts
+++ b/server/src/domain/product/product.service.ts
@@ -21,7 +21,7 @@ export class ProductService {
 
   async findAllByQuery(
     query: TProductAllQuery,
-    userId = 2,
+    userId: number,
   ): Promise<TProductSummary[]> {
     const { locationId, categoryId } = query;
     if (!locationId) {
@@ -34,6 +34,7 @@ export class ProductService {
       );
     }
     if (!categoryId) query = { locationId };
+    if (!userId) userId = 0;
 
     try {
       const data = await this.productRepository
@@ -43,7 +44,7 @@ export class ProductService {
         .leftJoin('p.user', 'user')
         .leftJoin('p.location', 'location')
         .leftJoin('p.likes', 'like')
-        .leftJoinAndSelect(
+        .leftJoin(
           'image',
           'image',
           'image.id = (SELECT i.id FROM image i WHERE i.product_id = p.id LIMIT 1)',
@@ -63,6 +64,7 @@ export class ProductService {
         .addSelect('category.name', 'categoryName')
         .addSelect('COUNT(room.id)', 'rooms')
         .addSelect('COUNT(like.product_id)', 'likes')
+        .addSelect(`SUM(like.user_id = ${userId})`, 'isLike')
         .addSelect('image.url', 'titleImage')
         .where('p.locationId = :id', { id: locationId })
         .groupBy('p.id, image.id')


### PR DESCRIPTION
# 💬 세부사항

- Product Type을 수정했습니다.
- Product 전부를 읽어올 수 있는 API를 작성했습니다.
- 여러 개의 Product를 불러오는데 연관된 데이터가 많았기 때문에 `Querybuilder`를 사용해서 한 번의 쿼리로 처리했습니다.

## 📎 관련 이슈

close #37

## 😭 어려웠던 점 or 참고 사항

**하나의 쿼리에서 처리하려고 해서 힘들었습니다.**

- image 같은 경우 join 했을 때 여러 개의 이미지를 가져오는데 이를 제일 낮은 id 값의 image 값만 매칭시키는 것이 힘들었습니다.
    - 다음과 같이 처리했습니다.
    ```
    LEFT JOIN image image ON image.id = (SELECT i.id FROM image i WHERE i.product_id = `p`.`id` LIMIT 1)
    ```
- `isLike` 속성 같은 경우 현재 user가 해당 product를 좋아요하는지 나타내야 합니다.
    하지만 모든 좋아요의 값을 `count` 해야 하기 때문에 다음 값을 반환하도록 했습니다.
    `SUM(like.user_id = ${userId})`
    이 값으로 0 or 1 이상의 값 으로 true/false를 판단하도록 했습니다.

## 🖼 스크린샷

- 불러온 데이터
<img width="1332" alt="image" src="https://user-images.githubusercontent.com/55688122/185990040-07ce62ba-7036-4138-9c75-e70c4719e323.png">

<!-- 있는 경우만 추가해주세요 -->

## ⏰ 실제 소요 시간

8h