### PR TITLE
bug : 아이콘 클릭 시, 상품 클릭 이벤트 발생 해결

### DIFF
--- a/client/src/components/molecules/ImageBox.tsx
+++ b/client/src/components/molecules/ImageBox.tsx
@@ -16,14 +16,20 @@ interface IProps extends React.PropsWithChildren {
   src?: string;
   type?: EImageSize;
   alt?: string;
+  onClick?: () => void;
 }
 
-const ImageBox: React.FC<IProps> = ({ src, type, alt = 'product' }) => {
+const ImageBox: React.FC<IProps> = ({
+  src,
+  type,
+  alt = 'product',
+  onClick,
+}) => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [source, setSource] = useState<string>(src ?? '');
 
   return (
-    <ContainerDiv type={type}>
+    <ContainerDiv type={type} onClick={onClick}>
       {isLoading && <BoxSkeleton animation={'wave'} variant='rounded' />}
       <img
         src={source}

--- a/client/src/components/organisms/ProductItem.tsx
+++ b/client/src/components/organisms/ProductItem.tsx
@@ -146,6 +146,12 @@ const MainInfosDiv = styled.div`
 
 const BtnWrapperDiv = styled.div`
   flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   position: relative;
   top: -0.3rem;

--- a/client/src/components/organisms/ProductItem.tsx
+++ b/client/src/components/organisms/ProductItem.tsx
@@ -39,9 +39,9 @@ const ProductItem: React.FC<IProps> = ({ product, children }) => {
   };
 
   return (
-    <ContainerDiv onClick={moveToProduct}>
-      <ImageBox src={titleImage}></ImageBox>
-      <ContentDiv>
+    <ContainerDiv>
+      <ImageBox src={titleImage} onClick={moveToProduct}></ImageBox>
+      <ContentDiv onClick={moveToProduct}>
         <section className='main'>
           <MainInfosDiv>
             <h3 className='title'>{title}</h3>
@@ -54,8 +54,6 @@ const ProductItem: React.FC<IProps> = ({ product, children }) => {
               {price === 0 ? '무료나눔' : `${price?.toLocaleString()}원`}
             </div>
           </MainInfosDiv>
-
-          <BtnWrapperDiv>{children}</BtnWrapperDiv>
         </section>
 
         <section className='sub'>
@@ -73,6 +71,7 @@ const ProductItem: React.FC<IProps> = ({ product, children }) => {
           )}
         </section>
       </ContentDiv>
+      <BtnWrapperDiv>{children}</BtnWrapperDiv>
     </ContainerDiv>
   );
 };

--- a/client/src/components/organisms/SaleList.tsx
+++ b/client/src/components/organisms/SaleList.tsx
@@ -8,8 +8,7 @@ import Dropdown from '@components/molecules/Dropdown';
 import { userMenuAPI } from '@apis/product';
 import ProductItem from './ProductItem';
 import type { TProductSummary } from '@fleamarket/common';
-
-const dropDownList = ['수정하기', '삭제하기'];
+import { dropDownList } from '@constants/dropDownList';
 
 const SaleList: React.FC = () => {
   const Auth = useRecoilValue(authAtom);

--- a/client/src/constants/dropDownList.ts
+++ b/client/src/constants/dropDownList.ts
@@ -1,0 +1,1 @@
+export const dropDownList = ['수정하기', '삭제하기'];

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -10,9 +10,14 @@ import { getProductAllAPI } from '@apis/product';
 import Heart from '@components/molecules/Heart';
 import { useRecoilValue } from 'recoil';
 import { categoryAtom } from '@stores/ActionInfoRecoil';
+import { authAtom } from '@stores/AuthRecoil';
+import Dropdown from '@components/molecules/Dropdown';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import { dropDownList } from '@constants/dropDownList';
 
 const Main: React.FC = () => {
   const currentCategory = useRecoilValue(categoryAtom);
+  const Auth = useRecoilValue(authAtom);
 
   const {
     isLoading,
@@ -30,6 +35,15 @@ const Main: React.FC = () => {
       retry: 0,
     },
   );
+
+  const handleClick = (value: string) => {
+    // 함수 로직 작성 나중에 실제 데이터 이용시 수정
+    if (value === '수정하기') {
+      //
+    } else {
+      //
+    }
+  };
 
   if (isError)
     return (
@@ -57,7 +71,13 @@ const Main: React.FC = () => {
       <ContentWrapperDiv id='item'>
         {productList.map((product) => (
           <ProductItem key={product.id} product={product}>
-            <Heart isLike={!!product.isLike}></Heart>
+            {product.userId === Auth?.id ? (
+              <Dropdown dropDownList={dropDownList} handleClick={handleClick}>
+                <MoreVertIcon />
+              </Dropdown>
+            ) : (
+              <Heart isLike={!!product.isLike}></Heart>
+            )}
           </ProductItem>
         ))}
       </ContentWrapperDiv>


### PR DESCRIPTION
# 💬 세부사항

아이콘 클릭 시, 아이콘 상위에 해당하는 상품 이벤트 클릭 이벤트가 발생하는 문제 해결 
+ 상품 목록에서 로그인한 유저의 상품일 경우 아이콘 다르게 분기 처리

## 📎 관련 이슈

close #84 

## 😭 어려웠던 점 or 참고 사항

기존 문제 상황 : 상품 클릭 시, 상품 디테일 페이지로 이동하는데, 상품안에 있는 아이콘 클릭 시에도 이벤트 캡처링으로 상품 디테일 페이지로 이동했었습니다. 그래서 stopPropagation()의 옵션을 통해 아이콘을 사용하는 모든 곳에서 적용할려고 했으나, 직접 정의한 이벤트는 처리할 수 있었지만, MUI의 이벤트에서는 적용할 방법을 찾지 못해 시간상 컴포넌트 밖으로 아이콘을 분리하는 식으로 해결했습니다. 
stopPropagation()

## 🖼 스크린샷

## ⏰ 실제 소요 시간

1시간